### PR TITLE
[chore|v-2.0.11] Bump version for frontend v2.0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Here are the two ways to run the application locally on http://localhost:3000/
 
 This application provides container images for demonstration purposes.
 
-DockerHub: https://hub.docker.com/r/tractusx/sdefrontend
+DockerHub: https://hub.docker.com/r/tractusx/managed-simple-data-exchanger-frontend 
 
 Eclipse Tractus-X product(s) installed within the image:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "managed-simple-data-exchanger-frontend",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "managed-simple-data-exchanger-frontend",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@mui/icons-material": "^5.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "managed-simple-data-exchanger-frontend",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "Managed Simple Data Exchanger Frontend",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Description
- Bump version for frontend v2.0.11.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
