### PR TITLE
[chore|sde] Bumped version 2.3.1 for helm charts to match with backend release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Simple Data Exchanger Frontend.
 
+## [2.3.1] -  2023-11-30
+### Changed
+- Bumped version to 2.3.1 for helm charts to match with backend release.
+
 ## [2.3.0] -  2023-11-29
 ### Changed
-- Bumped version to 2.3.0 for helm charts.
+- Bumped version to 2.3.0 for helm charts to match with backend release.
 
 ## [2.1.4] -  non-released
 ### Fixed
@@ -217,8 +221,9 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
 - Compliance with Catena-X Guidelines
 - Integration with Digital Twin registry service.
 
-[unreleased]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend/compare/v2.1.1...main
-[2.3.0]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend/compare/v2.3.0...v2.1.1
+[unreleased]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend/compare/v2.3.1...main
+[2.3.1]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend/compare/v2.3.0...v2.3.1
+[2.3.0]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend/compare/v2.1.1...v2.3.0
 [2.1.1]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend/compare/v2.0.10...v2.0.11
 [2.0.11]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend/compare/v2.0.10...v2.0.11

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "managed-simple-data-exchanger-frontend",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "managed-simple-data-exchanger-frontend",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@mui/icons-material": "^5.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "managed-simple-data-exchanger-frontend",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Managed Simple Data Exchanger Frontend",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Description
- Bumped version to 2.3.1 for helm charts to match with backend release.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
