### PR TITLE
[Fix:sde-frontend] docker image security fix- v2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Simple Data Exchanger Frontend.
 
+## [2.3.3] -  2023-12-06
+### Fixed
+- docker image change for security fixes.
+
 ## [2.3.2] -  2023-12-01
 ### Changed
 - Bumped version to 2.3.2 for helm charts to match with backend release.
@@ -225,7 +229,8 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
 - Compliance with Catena-X Guidelines
 - Integration with Digital Twin registry service.
 
-[unreleased]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend/compare/v2.3.2...main
+[unreleased]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend/compare/v2.3.3...main
+[2.3.3]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend/compare/v2.3.2...v2.3.3
 [2.3.2]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend/compare/v2.3.1...v2.3.2
 [2.3.1]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend/compare/v2.1.1...v2.3.0

--- a/DOCKER_NOTICE.md
+++ b/DOCKER_NOTICE.md
@@ -12,7 +12,7 @@ Eclipse Tractus-X product(s) installed within the image:
 - Project license: [Apache License, Version 2.0] https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/blob/main/LICENSE
 
 **Used base image**
-- [nginxinc/nginx-unprivileged:alpine3.18-perl]
+- [nginxinc/nginx-unprivileged:mainline-alpine3.18-perl]
 - Dockerfile: [nginxinc/nginx-unprivileged:alpine](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template)
 - GitHub project: [https://github.com/nginxinc/docker-nginx-unprivileged](https://github.com/nginxinc/docker-nginx-unprivileged)
 - DockerHub: [https://hub.docker.com/r/nginxinc/nginx-unprivileged](https://hub.docker.com/r/nginxinc/nginx-unprivileged)

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN npm install && npm run build
 
 #### Stage 2: Serve the application from Nginx
 
-FROM nginxinc/nginx-unprivileged:alpine3.18-perl
+FROM nginxinc/nginx-unprivileged:mainline-alpine3.18-perl
 # Nginx config
 RUN rm -rf /etc/nginx/conf.d
 USER root 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Eclipse Tractus-X product(s) installed within the image:
 - Project license: [Apache License, Version 2.0] https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/blob/main/LICENSE
 
 **Used base image**
-- [nginxinc/nginx-unprivileged:alpine3.18-perl]
+- [nginxinc/nginx-unprivileged:mainline-alpine3.18-perl]
 - Dockerfile: [nginxinc/nginx-unprivileged:alpine](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template)
 - GitHub project: [https://github.com/nginxinc/docker-nginx-unprivileged](https://github.com/nginxinc/docker-nginx-unprivileged)
 - DockerHub: [https://hub.docker.com/r/nginxinc/nginx-unprivileged](https://hub.docker.com/r/nginxinc/nginx-unprivileged)


### PR DESCRIPTION
## Description
- Docker image change to fix security issues of Image.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
