### PR TITLE
fix(blank screen): lazy import pages reverted

### DIFF
--- a/src/helpers/RouteHelper.tsx
+++ b/src/helpers/RouteHelper.tsx
@@ -16,18 +16,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-import { lazy, ReactElement } from 'react';
+import { ReactElement } from 'react';
 
-const ConsumeData = lazy(() => import('../pages/ConsumeData'));
-const ConsumerContracts = lazy(() => import('../pages/ConsumerContracts'));
-const CreateData = lazy(() => import('../pages/CreateData'));
-const Help = lazy(() => import('../pages/Help'));
-const Home = lazy(() => import('../pages/Home'));
-const Logout = lazy(() => import('../pages/Logout'));
-const PageNotFound = lazy(() => import('../pages/PageNotFound'));
-const ProviderContracts = lazy(() => import('../pages/ProviderContracts'));
-const UploadHistoryNew = lazy(() => import('../pages/UploadHistoryNew'));
-const About = lazy(() => import('../pages/About'));
+import About from '../pages/About';
+import ConsumeData from '../pages/ConsumeData';
+import ConsumerContracts from '../pages/ConsumerContracts';
+import CreateData from '../pages/CreateData';
+import Help from '../pages/Help';
+import Home from '../pages/Home';
+import Logout from '../pages/Logout';
+import PageNotFound from '../pages/PageNotFound';
+import ProviderContracts from '../pages/ProviderContracts';
+import UploadHistoryNew from '../pages/UploadHistoryNew';
 
 export interface IRoutes {
   key?: string;


### PR DESCRIPTION
## Description

lazy import pages reverted to prevent blank screen issue

## Pre-review checks

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
