### PR TITLE
fix(usage policy): Duration removed

### DIFF
--- a/src/components/ContractsTable.tsx
+++ b/src/components/ContractsTable.tsx
@@ -22,8 +22,7 @@ import CancelIcon from '@mui/icons-material/Cancel';
 import { Box, Grid, LinearProgress } from '@mui/material';
 import { DataGrid, GridColDef, GridRenderCellParams, GridToolbar, GridValidRowModel } from '@mui/x-data-grid';
 import { IconButton, LoadingButton, Tooltips, Typography } from 'cx-portal-shared-components';
-import { capitalize, find } from 'lodash';
-import moment from 'moment';
+import { capitalize } from 'lodash';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -31,9 +30,8 @@ import { setPageLoading } from '../features/app/slice';
 import { useDeleteContractMutation, useGetContractsQuery } from '../features/provider/contracts/apiSlice';
 import { useAppDispatch } from '../features/store';
 import { handleBlankCellValues, MAX_CONTRACTS_AGREEMENTS } from '../helpers/ConsumerOfferHelper';
-import { IDefaultObject } from '../models/Common';
-import { CONTRACT_STATES, DURATION_UNIT_MAPPING, STATUS_COLOR_MAPPING, USER_TYPE_SWITCH } from '../utils/constants';
-import { convertEpochToDate, epochToDate } from '../utils/utils';
+import { CONTRACT_STATES, STATUS_COLOR_MAPPING, USER_TYPE_SWITCH } from '../utils/constants';
+import { convertEpochToDate } from '../utils/utils';
 import NoDataPlaceholder from './NoDataPlaceholder';
 
 interface IContractsTable {
@@ -62,16 +60,6 @@ function ContractsTable({ type, title, subtitle }: IContractsTable) {
   });
 
   const [deleteContract, { isLoading: isDeleting }] = useDeleteContractMutation({});
-
-  function calculateEndDate(policies: IDefaultObject[], signingDate: number) {
-    if (policies?.length) {
-      const { durationUnit, value } = find(policies, e => e.type === 'DURATION');
-      const startDate = epochToDate(signingDate);
-      if (durationUnit) {
-        return moment(startDate).add(value, Object(DURATION_UNIT_MAPPING)[durationUnit]).format('DD/MM/YYYY HH:mm:ss');
-      } else return '-';
-    } else return '-';
-  }
 
   useEffect(() => {
     dispatch(setPageLoading(isLoading));
@@ -126,30 +114,8 @@ function ContractsTable({ type, title, subtitle }: IContractsTable) {
         ),
     },
     {
-      field: 'contractEndDate',
-      flex: 1,
-      headerName: t('content.contractHistory.columns.contractEndDate'),
-      sortingOrder: ['asc', 'desc'],
-      sortComparator: (v1, v2, param1: GridValidRowModel, param2: GridValidRowModel) => param2.id - param1.id,
-      valueGetter: ({ row }) => row.contractAgreementInfo,
-      valueFormatter: ({ value }) => calculateEndDate(value?.policies, value?.contractSigningDate),
-      renderCell: ({ row }) => (
-        <Tooltips
-          tooltipPlacement="top"
-          tooltipText={calculateEndDate(
-            row.contractAgreementInfo?.policies,
-            row.contractAgreementInfo?.contractSigningDate,
-          )}
-        >
-          <span>
-            {calculateEndDate(row.contractAgreementInfo?.policies, row.contractAgreementInfo?.contractSigningDate)}
-          </span>
-        </Tooltips>
-      ),
-    },
-    {
       field: 'state',
-      flex: 1,
+      maxWidth: 200,
       headerName: t('content.contractHistory.columns.state'),
       renderCell: renderContractAgreementStatus,
     },

--- a/src/components/policies/PoliciesDialog.tsx
+++ b/src/components/policies/PoliciesDialog.tsx
@@ -60,9 +60,6 @@ export default function PoliciesDialog() {
     uploadUrl,
     uploadData,
     uploadType,
-    duration,
-    durationValue,
-    durationUnit,
     purpose,
     purposeValue,
     role,
@@ -78,13 +75,12 @@ export default function PoliciesDialog() {
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    const durationCheck = duration === 'RESTRICTED' && durationValue === '';
     const purposeCheck = purpose === 'RESTRICTED' && isEmpty(purposeValue);
     const roleCheck = role === 'RESTRICTED' && roleValue === '';
     const customCheck = custom === 'RESTRICTED' && customValue === '';
-    setshowError(() => durationCheck || purposeCheck || roleCheck || customCheck);
+    setshowError(() => purposeCheck || roleCheck || customCheck);
     return () => {};
-  }, [duration, durationValue, purpose, purposeValue, role, roleValue, custom, customValue]);
+  }, [purpose, purposeValue, role, roleValue, custom, customValue]);
 
   const clearUpload = () => {
     dispatch(setPageLoading(false));
@@ -167,12 +163,6 @@ export default function PoliciesDialog() {
     type_of_access: accessType,
     row_data: uploadData,
     usage_policies: [
-      {
-        type: 'DURATION',
-        typeOfAccess: duration,
-        value: durationValue,
-        durationUnit: durationUnit.value,
-      },
       {
         type: 'ROLE',
         typeOfAccess: role,

--- a/src/components/policies/UsagePolicy.tsx
+++ b/src/components/policies/UsagePolicy.tsx
@@ -22,29 +22,18 @@ import { Box } from '@mui/material';
 import { Typography } from 'cx-portal-shared-components';
 import { useTranslation } from 'react-i18next';
 
-import { setDuration, setDurationValue, setPurpose } from '../../features/provider/policies/slice';
+import { setPurpose } from '../../features/provider/policies/slice';
 import { useAppDispatch, useAppSelector } from '../../features/store';
 import UsagePolicyItem from './UsagePolicyItem';
 
 export default function UsagePolicy() {
-  const { duration, durationValue, purpose } = useAppSelector(state => state.accessUsagePolicySlice);
+  const { purpose } = useAppSelector(state => state.accessUsagePolicySlice);
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
 
   return (
     <>
       <Typography fontWeight={'bold'}>{t('content.policies.usagePolicy')}</Typography>
-      <Box sx={{ mt: 2 }}>
-        <UsagePolicyItem
-          restrictionType={duration}
-          setRestrictionType={e => dispatch(setDuration(e))}
-          constraintType={t('content.policies.duration')}
-          displayText={t('content.policies.durationNote')}
-          labelText={t('content.common.enterValue')}
-          inputFreeText={durationValue}
-          setInputFreeText={e => dispatch(setDurationValue(e))}
-        />
-      </Box>
       <Box sx={{ mt: 4 }}>
         <UsagePolicyItem
           restrictionType={purpose}

--- a/src/components/policies/UsagePolicyItem.tsx
+++ b/src/components/policies/UsagePolicyItem.tsx
@@ -23,9 +23,9 @@ import { Input, SelectList } from 'cx-portal-shared-components';
 import { isEmpty } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
-import { setDurationUnit, setPurposeValue } from '../../features/provider/policies/slice';
+import { setPurposeValue } from '../../features/provider/policies/slice';
 import { useAppDispatch, useAppSelector } from '../../features/store';
-import { DURATION_UNITS, ONLY_NUM_REGEX, PURPOSE_VALUES } from '../../utils/constants';
+import { ONLY_NUM_REGEX, PURPOSE_VALUES } from '../../utils/constants';
 
 interface FreeTextProps {
   restrictionType: string;
@@ -46,7 +46,7 @@ export default function UsagePolicyItem({
   labelText,
   setInputFreeText,
 }: FreeTextProps) {
-  const { durationUnit, purposeValue } = useAppSelector(state => state.accessUsagePolicySlice);
+  const { purposeValue } = useAppSelector(state => state.accessUsagePolicySlice);
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
 
@@ -92,21 +92,6 @@ export default function UsagePolicyItem({
                   }}
                   sx={{ minWidth: 250 }}
                 />
-              )}
-              {constraintType === t('content.policies.duration') && (
-                <FormControl sx={{ minWidth: 150 }} size="small">
-                  <SelectList
-                    keyTitle="title"
-                    defaultValue={durationUnit}
-                    items={DURATION_UNITS}
-                    label={t('content.policies.selectDuration')}
-                    placeholder={t('content.policies.selectDuration')}
-                    disableClearable={true}
-                    onChangeItem={e => {
-                      dispatch(setDurationUnit(e));
-                    }}
-                  />
-                </FormControl>
               )}
               {constraintType === t('content.policies.purpose') && (
                 <FormControl sx={{ minWidth: 250 }} size="small">


### PR DESCRIPTION
## Description

- Duration usage policy removed since it is invalid from EDC side.
- End date in contracts list removed because it was calculated from duration policy.

## Pre-review checks

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
