### PR TITLE
[chore] readme updated and removed ghcr reference for image.

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -1,6 +1,6 @@
 #################################################################################
-# Copyright (c) 2023 T-Systems International GmbH
-# Copyright (c) 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2023,2024 T-Systems International GmbH
+# Copyright (c) 2023.2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -99,3 +99,5 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
           repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          # IMPORTANT: Adjust this to the actual path of your container image notice
+          readme-filepath: ./docker_notice.md

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -100,4 +100,4 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
           repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
           # IMPORTANT: Adjust this to the actual path of your container image notice
-          readme-filepath: ./docker_notice.md
+          readme-filepath: ./DOCKER_NOTICE.md

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Here are the two ways to run the application locally on http://localhost:3000/
     npm run build
     npm start
 
-### Running the image from GitHub container registry
+### Running the image 
 
-    export IMAGE=tractusx/sdefrontend:latest
+    export IMAGE=tractusx/managed-simple-data-exchanger-frontend:latest
     docker pull $IMAGE
     docker run --rm -d -p 3001:8080 --name sdefrontend $IMAGE
 

--- a/docs/Arc42.md
+++ b/docs/Arc42.md
@@ -5,8 +5,8 @@
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2021,2022,2023 T-Systems International GmbH
-- SPDX-FileCopyrightText: 2022,2023 Contributors to the Eclipse Foundation
+- SPDX-FileCopyrightText: 2021,2024 T-Systems International GmbH
+- SPDX-FileCopyrightText: 2022,2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend
 
 ## Table of contents
@@ -190,11 +190,11 @@ There is a web interface between frontend and backend.<br /><br />
 
 Detailed API specs available under:
 
-[https://github.com/catenax-ng/tx-managed-simple-data-exchanger-backend/blob/main/modules/sde-core/src/main/resources/sde-open-api.yml](https://github.com/catenax-ng/tx-managed-simple-data-exchanger-backend/blob/main/modules/sde-core/src/main/resources/sde-open-api.yml)
+[https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/blob/main/modules/sde-core/src/main/resources/sde-open-api.yml](https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/blob/main/modules/sde-core/src/main/resources/sde-open-api.yml)
 
-[https://github.com/catenax-ng/tx-managed-simple-data-exchanger-backend/tree/main#restful-apis-of-dft-simple-data-exchanger](https://github.com/catenax-ng/tx-managed-simple-data-exchanger-backend/tree/main#restful-apis-of-dft-simple-data-exchanger)
+[https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/tree/main#restful-apis-of-dft-simple-data-exchanger](https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/tree/main#restful-apis-of-dft-simple-data-exchanger)
 
-Backend API Swagger-ui : [https://dft-api.int.demo.catena-x.net/api/swagger-ui/index.html](https://dft-api.int.demo.catena-x.net/api/swagger-ui/index.html)
+Backend API Swagger-ui Ex: [https://dft-api.int.demo.catena-x.net/api/swagger-ui/index.html](https://dft-api.int.demo.catena-x.net/api/swagger-ui/index.html)
 
 <br />
 

--- a/docs/Arc42.md
+++ b/docs/Arc42.md
@@ -194,7 +194,7 @@ Detailed API specs available under:
 
 [https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/tree/main#restful-apis-of-dft-simple-data-exchanger](https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/tree/main#restful-apis-of-dft-simple-data-exchanger)
 
-Backend API Swagger-ui Ex: [https://dft-api.int.demo.catena-x.net/api/swagger-ui/index.html](https://dft-api.int.demo.catena-x.net/api/swagger-ui/index.html)
+Backend API Swagger-ui Ex: [https://domain_url/api/swagger-ui/index.html](https://domain_url/api/swagger-ui/index.html)
 
 <br />
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -5,8 +5,8 @@
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2021,2022,2023 T-Systems International GmbH
-- SPDX-FileCopyrightText: 2022,2023 Contributors to the Eclipse Foundation
+- SPDX-FileCopyrightText: 2021,2024 T-Systems International GmbH
+- SPDX-FileCopyrightText: 2022,2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend
 
 ## Table of contents


### PR DESCRIPTION
## Description

-  readme updated and removed ghcr reference for image.

#72 - fixed.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
