### PR TITLE
chore removed duplicate docker notice reference from Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,29 +29,6 @@ Here are the two ways to run the application locally on http://localhost:3000/
     docker pull $IMAGE
     docker run --rm -d -p 3001:8080 --name sdefrontend $IMAGE
 
-## Notice for Docker image
-
-This application provides container images for demonstration purposes.
-
-DockerHub: https://hub.docker.com/r/tractusx/managed-simple-data-exchanger-frontend 
-
-Eclipse Tractus-X product(s) installed within the image:
-
-- GitHub: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend
-- Project home: https://projects.eclipse.org/projects/automotive.tractusx
-- Dockerfile: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend/blob/main/Dockerfile
-- Project license: [Apache License, Version 2.0] https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/blob/main/LICENSE
-
-**Used base image**
-- [nginxinc/nginx-unprivileged:alpine3.18-perl]
-- Dockerfile: [nginxinc/nginx-unprivileged:alpine](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template)
-- GitHub project: [https://github.com/nginxinc/docker-nginx-unprivileged](https://github.com/nginxinc/docker-nginx-unprivileged)
-- DockerHub: [https://hub.docker.com/r/nginxinc/nginx-unprivileged](https://hub.docker.com/r/nginxinc/nginx-unprivileged)
-
-As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
-
-As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.
-
 ## License
 
 Distributed under the Apache 2.0 License.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ Here are the two ways to run the application locally on http://localhost:3000/
 
 Distributed under the Apache 2.0 License.
 See [LICENSE](./LICENSE) for more information.
+
+## Notice for Docker image
+
+Bellow you can find the information regarding Docker Notice for this application.
+
+  - [Managed-simple-data-exchanger](DOCKER_NOTICE.md)


### PR DESCRIPTION
## Description

- chore removed duplicate docker notice reference from Readme.md
- TRG 4.06 updated in file.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
